### PR TITLE
Unifica lógica de serializers do Snscrape

### DIFF
--- a/twitter_scrapping/tweets/fixtures.py
+++ b/twitter_scrapping/tweets/fixtures.py
@@ -90,3 +90,4 @@ tweet1_incomplete = deepcopy(tweet1)
 tweet1_incomplete_remove_fields = ['id', 'rawContent', 'replyCount', 'conversationId']
 for attr in tweet1_incomplete_remove_fields:
     delattr(tweet1_incomplete, attr)
+    

--- a/twitter_scrapping/tweets/fixtures.py
+++ b/twitter_scrapping/tweets/fixtures.py
@@ -1,7 +1,32 @@
+from copy import deepcopy
 from django.utils import timezone
 from snscrape.modules.twitter import User as SNUser, Tweet as SNTweet
 
 tz = timezone.get_default_timezone()
+
+user1 = SNUser(
+    username='GergelyOrosz',
+    id=30192824,
+    displayname='Gergely Orosz',
+    rawDescription='Writing @Pragmatic_Eng & @EngGuidebook.',
+    created=timezone.datetime(2009, 4, 10, 10, 1, 11, tzinfo=tz),
+    followersCount=202171,
+    friendsCount=1368,
+    statusesCount=24961,
+    listedCount=2268,
+    location='Amsterdam, The Netherlands',
+)
+
+user1_updated_dict = {
+    'followersCount': 202173,
+    'friendsCount': 1368,
+    'statusesCount': 24965,
+    'listedCount': 2268,
+}
+user1_updated = deepcopy(user1)
+for attr, value in user1_updated_dict.items():
+    setattr(user1_updated, attr, value)
+
 
 tweet1 = SNTweet(
     url='https://twitter.com/GergelyOrosz/status/1636295637187584000',
@@ -9,38 +34,47 @@ tweet1 = SNTweet(
     rawContent='Test tweet content',
     renderedContent='Test tweet content',
     id=1636295637187584000,
-    user=SNUser(
-        username='GergelyOrosz',
-        id=30192824,
-        displayname='Gergely Orosz',
-        rawDescription='Writing @Pragmatic_Eng & @EngGuidebook. ',
-        renderedDescription='Writing @Pragmatic_Eng & @EngGuidebook. Advisor @mobile__dev. Uber & Skype alumni. Great tech jobs: pragmaticurl.com/talent. Contact: pragmaticurl.com/contact',
-        descriptionLinks=['http://pragmaticurl.com/talent', 'http://pragmaticurl.com/contact'],
-        verified=False,
-        created=timezone.datetime(2009, 4, 10, 10, 1, 11, tzinfo=tz),
-        followersCount=202171,
-        friendsCount=1368,
-        statusesCount=24961,
-        favouritesCount=32295,
-        listedCount=2268,
-        mediaCount=2511,
-        location='Amsterdam, The Netherlands',
-        protected=False,
-    ),
+    user=user1,
     replyCount=22,
     retweetCount=13,
     likeCount=235,
     quoteCount=2,
+    viewCount=161280,
     conversationId=1636295637187584000,
-    lang='en',
-    media=None,
     retweetedTweet=None,
     inReplyToTweetId=None,
     inReplyToUser=None,
-    mentionedUsers=None,
-    coordinates=None,
-    place=None,
-    hashtags=None,
-    cashtags=None,
-    viewCount=161280,
+    lang='en',
 )
+
+tweet1_updated_tweet_dict = {
+    'replyCount': 32,
+    'retweetCount': 13,
+    'likeCount': 335,
+    'quoteCount': 2,
+    'viewCount': 181280,
+}
+tweet1_updated_tweet = deepcopy(tweet1)
+for attr, value in tweet1_updated_tweet_dict.items():
+    setattr(tweet1_updated_tweet, attr, value)
+
+
+tweet1_updated_user_dict = {
+    'user': user1_updated,
+}
+tweet1_updated_user = deepcopy(tweet1)
+for attr, value in tweet1_updated_user_dict.items():
+    setattr(tweet1_updated_user, attr, value)
+
+
+tweet1_updated_both_dict = {
+    'user': user1_updated,
+    'replyCount': 32,
+    'retweetCount': 13,
+    'likeCount': 335,
+    'quoteCount': 2,
+    'viewCount': 181280,
+}
+tweet1_updated_both = deepcopy(tweet1)
+for attr, value in tweet1_updated_both_dict.items():
+    setattr(tweet1_updated_both, attr, value)

--- a/twitter_scrapping/tweets/fixtures.py
+++ b/twitter_scrapping/tweets/fixtures.py
@@ -26,6 +26,12 @@ user1_updated_dict = {
 user1_updated = deepcopy(user1)
 for attr, value in user1_updated_dict.items():
     setattr(user1_updated, attr, value)
+    
+    
+user1_incomplete = deepcopy(user1)
+user1_incomplete_remove_fields = ['username', 'followersCount']
+for attr in user1_incomplete_remove_fields:
+    delattr(user1_incomplete, attr)
 
 
 tweet1 = SNTweet(
@@ -78,3 +84,9 @@ tweet1_updated_both_dict = {
 tweet1_updated_both = deepcopy(tweet1)
 for attr, value in tweet1_updated_both_dict.items():
     setattr(tweet1_updated_both, attr, value)
+
+
+tweet1_incomplete = deepcopy(tweet1)
+tweet1_incomplete_remove_fields = ['id', 'rawContent', 'replyCount', 'conversationId']
+for attr in tweet1_incomplete_remove_fields:
+    delattr(tweet1_incomplete, attr)

--- a/twitter_scrapping/tweets/fixtures.py
+++ b/twitter_scrapping/tweets/fixtures.py
@@ -1,0 +1,46 @@
+from django.utils import timezone
+from snscrape.modules.twitter import User as SNUser, Tweet as SNTweet
+
+tz = timezone.get_default_timezone()
+
+tweet1 = SNTweet(
+    url='https://twitter.com/GergelyOrosz/status/1636295637187584000',
+    date=timezone.datetime(2023, 3, 16, 9, 17, 35, tzinfo=tz),
+    rawContent='Test tweet content',
+    renderedContent='Test tweet content',
+    id=1636295637187584000,
+    user=SNUser(
+        username='GergelyOrosz',
+        id=30192824,
+        displayname='Gergely Orosz',
+        rawDescription='Writing @Pragmatic_Eng & @EngGuidebook. ',
+        renderedDescription='Writing @Pragmatic_Eng & @EngGuidebook. Advisor @mobile__dev. Uber & Skype alumni. Great tech jobs: pragmaticurl.com/talent. Contact: pragmaticurl.com/contact',
+        descriptionLinks=['http://pragmaticurl.com/talent', 'http://pragmaticurl.com/contact'],
+        verified=False,
+        created=timezone.datetime(2009, 4, 10, 10, 1, 11, tzinfo=tz),
+        followersCount=202171,
+        friendsCount=1368,
+        statusesCount=24961,
+        favouritesCount=32295,
+        listedCount=2268,
+        mediaCount=2511,
+        location='Amsterdam, The Netherlands',
+        protected=False,
+    ),
+    replyCount=22,
+    retweetCount=13,
+    likeCount=235,
+    quoteCount=2,
+    conversationId=1636295637187584000,
+    lang='en',
+    media=None,
+    retweetedTweet=None,
+    inReplyToTweetId=None,
+    inReplyToUser=None,
+    mentionedUsers=None,
+    coordinates=None,
+    place=None,
+    hashtags=None,
+    cashtags=None,
+    viewCount=161280,
+)

--- a/twitter_scrapping/tweets/models.py
+++ b/twitter_scrapping/tweets/models.py
@@ -11,8 +11,6 @@ class TwitterUser(TimeStampedModel):
     account_created_at = models.DateTimeField('Twitter account creation date')
     location = models.CharField(max_length=50, blank=True)
     followers_count = models.IntegerField(default=0)
-    
-    # Apagar e recriar migrations
     following_count = models.IntegerField(default=0)
     tweet_count = models.IntegerField(default=0)
     listed_count = models.IntegerField(default=0)

--- a/twitter_scrapping/tweets/tasks.py
+++ b/twitter_scrapping/tweets/tasks.py
@@ -52,6 +52,16 @@ def scrape_tweets(username, since, until, recurse=False):
     new_tweets = []
     for tweet_data in tweets_and_replies:
         try:
+            # To Do:
+            # Converter tweet_data para dicionarios e jogar direto para o serializer
+            # data = tweet_data.__dict__
+            # data['user'] = tweet_data.user.__dict__
+            # tweet_serializer = SnscrapeTweetSerializer(data=data)
+            
+            # Criar método .create() no SnscrapeTweetSerializer
+            # Testar como o serializer vai se portar em casos de criação e atualização
+            
+            
             user_serializer = SnscrapeTwitterUserSerializer(data=tweet_data.user.__dict__)
             if not user_serializer.is_valid():
                 logger.error(f'Erro ao salvar usuario do tweet {tweet_data}: {user_serializer.errors}')

--- a/twitter_scrapping/tweets/tasks.py
+++ b/twitter_scrapping/tweets/tasks.py
@@ -24,11 +24,11 @@ def scrape_tweets(username, since, until, recurse=False):
     else:
         mode = sntwitter.TwitterTweetScraperMode.SCROLL
     query = f'from:{username} since:{since} until:{until}'
-    user_scrapping_results = sntwitter.TwitterSearchScraper(query)
-
+    user_scrapping_results = sntwitter.TwitterSearchScraper(query).get_items()
+    
     logger.info(f'Iterando tweets do usuário "{username}"')
     tweet_ids = []
-    for tweet in user_scrapping_results.get_items():
+    for tweet in user_scrapping_results:
         tweet_ids.append(tweet.id)
     logger.info(f'Encontrados {len(tweet_ids)} tweets')
 

--- a/twitter_scrapping/tweets/tests.py
+++ b/twitter_scrapping/tweets/tests.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from .fixtures import tweet1, tweet1_updated_tweet, tweet1_updated_user, tweet1_updated_both, tweet1_incomplete
 from .models import Tweet, TwitterUser
 from .serializers import SnscrapeTwitterUserSerializer, SnscrapeTweetSerializer
-from .tasks import save_scrapped_tweet
+from .tasks import save_scrapped_tweet, scrape_tweets
 
 
 tz = timezone.get_default_timezone()
@@ -211,15 +211,27 @@ class TasksTest(TestCase):
         self.tweet1 = deepcopy(tweet1)
         self.tweet1_incomplete = deepcopy(tweet1_incomplete)
     
-    @patch('tweets.serializers.SnscrapeTweetSerializer.save')
-    def test_save_scrapped_tweet(self, save_mock):
-        save_scrapped_tweet(self.tweet1)
-        save_mock.assert_called()
+    # @patch('tweets.serializers.SnscrapeTweetSerializer.save')
+    # def test_save_scrapped_tweet(self, save_mock):
+    #     save_scrapped_tweet(self.tweet1)
+    #     save_mock.assert_called()
     
-    @patch('tweets.serializers.SnscrapeTweetSerializer.save')
-    def test_save_invalid_scrapped_tweet(self, save_mock):
-        from rest_framework.serializers import ValidationError
-        with self.assertRaises(ValidationError):
-            save_scrapped_tweet(self.tweet1_incomplete)
-            save_mock.assert_not_called()
+    # @patch('tweets.serializers.SnscrapeTweetSerializer.save')
+    # def test_save_invalid_scrapped_tweet(self, save_mock):
+    #     from rest_framework.serializers import ValidationError
+    #     with self.assertRaises(ValidationError):
+    #         save_scrapped_tweet(self.tweet1_incomplete)
+    #         save_mock.assert_not_called()
+    
+    @patch('snscrape.modules.twitter.TwitterSearchScraper.get_items')
+    @patch('snscrape.modules.twitter.TwitterTweetScraper.get_items')
+    @patch('tweets.tasks.save_scrapped_tweet')
+    def test_scrape_tweets(self, save_scrapped_tweet_mock, tweet_scrapper_mock, search_scrapper_mock):
+        search_scrapper_mock.side_effect = [[self.tweet1].__iter__()]
+        tweet_scrapper_mock.side_effect = [[self.tweet1].__iter__()]
+        username = 'GergelyOrosz'
+        since = '2023-03-15'
+        until = '2023-03-16'
         
+        scrape_tweets(username, since, until)
+        save_scrapped_tweet_mock.assert_called_with(self.tweet1)

--- a/twitter_scrapping/tweets/tests.py
+++ b/twitter_scrapping/tweets/tests.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
 from django.utils import timezone
-from snscrape.modules.twitter import User as SNScrapeUser
+from snscrape.modules.twitter import User as SNUser, Tweet as SNTweet
 
+from .fixtures import tweet1
 from .models import Tweet, TwitterUser
 from .serializers import SnscrapeTwitterUserSerializer, SnscrapeTweetSerializer
 
@@ -105,7 +106,7 @@ class SerializerTests(TestCase):
             'rawContent': 'When I talked w ~70 companies about what vendor costs they are reducing, the two most frequently mentioned was AWS/GCP and Datadog. Simply because they were usually by far the biggest spend.\n\nGiven DDG is usage based, reducing it is usually easier.\n\nMore:  https://t.co/NxOVEcYCds',
             'renderedContent': 'When I talked w ~70 companies about what vendor costs they are reducing, the two most frequently mentioned was AWS/GCP and Datadog. Simply because they were usually by far the biggest spend.\n\nGiven DDG is usage based, reducing it is usually easier.\n\nMore:  newsletter.pragmaticengineer.com/p/vendor-spend…',
             'id': 1636295637187584000,
-            'user': None,
+            'user': self.snscrape_user_kwargs,
             'replyCount': 18,
             'retweetCount': 10,
             'likeCount': 180,
@@ -128,43 +129,24 @@ class SerializerTests(TestCase):
             'viewCount': 111208,
         }
     
-    def test_valid_user_kwargs(self):
-        serializer = SnscrapeTwitterUserSerializer(data=self.snscrape_user_kwargs)
+    def test_valid_kwargs(self):
+        serializer = SnscrapeTweetSerializer(data=self.snscrape_tweet_kwargs)
+        serializer.is_valid()
+        print(serializer.errors)
         self.assertTrue(serializer.is_valid())
         
         
 class SnscrapeTweetSerializerTest(TestCase):
     
     def setUp(self):
-        self.user = TwitterUser.objects.create(
-            twitter_id='123', 
-            username='testuser',
-            display_name='Test User', 
-            description='Just a test',
-            account_created_at=timezone.datetime(2022, 1, 1, 12, 0, 0, 0, tz), 
-            location='Testville',
-            followers_count=10
-        )
-        dummy_user = SNScrapeUser(id='123', username='testuser')
-        self.tweet_data = {
-            'id': '12345',
-            'user': dummy_user,
-            'rawContent': 'Test tweet content',
-            'date': timezone.datetime(2022, 1, 1, 12, 0, 0, 0, tz),
-            'inReplyToTweetId': '98765',
-            'conversationId': '54321',
-            'replyCount': 1,
-            'retweetCount': 2,
-            'likeCount': 3,
-            'quoteCount': 4,
-        }
-    
-    def test_snscrape_tweet_serializer(self):
-        serializer = SnscrapeTweetSerializer(data=self.tweet_data)
+        self.tweet = tweet1
+        
+    def test_valid_kwargs(self):
+        serializer = SnscrapeTweetSerializer(data=self.tweet)
         self.assertTrue(serializer.is_valid())
         tweet = serializer.save()
-        
-        self.assertEqual(tweet.twitter_id, '12345')
+
+        self.assertEqual(tweet.twitter_id, '1636295637187584000')
         self.assertEqual(tweet.content, 'Test tweet content')
         self.assertEqual(tweet.published_at, timezone.datetime(2022, 1, 1, 12, 0, 0, 0, tz))
         self.assertEqual(tweet.in_reply_to_id, '98765')
@@ -173,3 +155,199 @@ class SnscrapeTweetSerializerTest(TestCase):
         self.assertEqual(tweet.retweet_count, 2)
         self.assertEqual(tweet.like_count, 3)
         self.assertEqual(tweet.quote_count, 4)
+    
+    # def test_snscrape_tweet_serializer(self):
+    #     serializer = SnscrapeTweetSerializer(data=self.tweet_data)
+    #     self.assertTrue(serializer.is_valid())
+    #     tweet = serializer.save()
+        
+    #     self.assertEqual(tweet.twitter_id, '12345')
+    #     self.assertEqual(tweet.content, 'Test tweet content')
+    #     self.assertEqual(tweet.published_at, timezone.datetime(2022, 1, 1, 12, 0, 0, 0, tz))
+    #     self.assertEqual(tweet.in_reply_to_id, '98765')
+    #     self.assertEqual(tweet.conversation_id, '54321')
+    #     self.assertEqual(tweet.reply_count, 1)
+    #     self.assertEqual(tweet.retweet_count, 2)
+    #     self.assertEqual(tweet.like_count, 3)
+    #     self.assertEqual(tweet.quote_count, 4)
+
+
+
+
+
+
+    #     tweet = SNTweet(
+    #         url='https://twitter.com/GergelyOrosz/status/1636295637187584000',
+    #         date=timezone.datetime(2023, 3, 16, 9, 17, 35, tzinfo=tz),
+    #         rawContent='When I talked w ~70 companies about what vendor costs they are reducing, the two most frequently mentioned was AWS/GCP and Datadog. Simply because they were usually by far the biggest spend.\n\nGiven DDG is usage based, reducing it is usually easier.\n\nMore:  https://t.co/NxOVEcYCds',
+    #         renderedContent='When I talked w ~70 companies about what vendor costs they are reducing, the two most frequently mentioned was AWS/GCP and Datadog. Simply because they were usually by far the biggest spend.\n\nGiven DDG is usage based, reducing it is usually easier.\n\nMore:  newsletter.pragmaticengineer.com/p/vendor-spend…',
+    #         id=1636295637187584000,
+    #         user=User(
+    #             username='GergelyOrosz',
+    #             id=30192824,
+    #             displayname='Gergely Orosz',
+    #             rawDescription='Writing @Pragmatic_Eng & @EngGuidebook. Advisor @mobile__dev. Uber & Skype alumni. Great tech jobs: https://t.co/MJ0eAtlaS1. Contact: https://t.co/POWftUprCb',
+    #             renderedDescription='Writing @Pragmatic_Eng & @EngGuidebook. Advisor @mobile__dev. Uber & Skype alumni. Great tech jobs: pragmaticurl.com/talent. Contact: pragmaticurl.com/contact',
+    #             descriptionLinks=[
+    #                 TextLink(
+    #                     text='pragmaticurl.com/talent',
+    #                     url='http://pragmaticurl.com/talent',
+    #                     tcourl='https://t.co/MJ0eAtlaS1',
+    #                     indices=(100, 123)
+    #                 ),
+    #                 TextLink(
+    #                     text='pragmaticurl.com/contact',
+    #                     url='http://pragmaticurl.com/contact',
+    #                     tcourl='https://t.co/POWftUprCb',
+    #                     indices=(134, 157))
+    #             ],
+    #             verified=False,
+    #             created=timezone.datetime(2009, 4, 10, 10, 1, 11, tzinfo=tz),
+    #             followersCount=202171,
+    #             friendsCount=1368,
+    #             statusesCount=24961,
+    #             favouritesCount=32295,
+    #             listedCount=2268,
+    #             mediaCount=2511,
+    #             location='Amsterdam, The Netherlands',
+    #             protected=False,
+    #             link=TextLink(
+    #                 text='pragmaticengineer.com',
+    #                 url='https://pragmaticengineer.com/',
+    #                 tcourl='https://t.co/x8RulFU4ID',
+    #                 indices=(0, 23)
+    #             ),
+    #             profileImageUrl='https://pbs.twimg.com/profile_images/673095429748350976/ei5eeouV_normal.png',
+    #             profileBannerUrl='https://pbs.twimg.com/profile_banners/30192824/1619604364',
+    #             label=None
+    #         ),
+    #         replyCount=22,
+    #         retweetCount=13,
+    #         likeCount=235,
+    #         quoteCount=2,
+    #         conversationId=1636295637187584000,
+    #         lang='en',
+    #         source=None,
+    #         sourceUrl=None,
+    #         sourceLabel=None,
+    #         links=[
+    #             TextLink(
+    #                 text='newsletter.pragmaticengineer.com/p/vendor-spend…',
+    #                 url='https://newsletter.pragmaticengineer.com/p/vendor-spend-cuts',
+    #                 tcourl='https://t.co/NxOVEcYCds',
+    #                 indices=(257, 280)
+    #             )
+    #         ],
+    #         media=None,
+    #         retweetedTweet=None,
+    #         quotedTweet=Tweet(
+    #             url='https://twitter.com/jamesacowling/status/1636168208377077760',
+    #             date=timezone.datetime(2023, 3, 16, 0, 51, 14, tzinfo=tz),
+    #             rawContent='Real monthly bills at an early-stage startup:\n\n@datadoghq: $11,386\n@getsentry: $134',
+    #             renderedContent='Real monthly bills at an early-stage startup:\n\n@datadoghq: $11,386\n@getsentry: $134',
+    #             id=1636168208377077760,
+    #             user=User(
+    #                 username='jamesacowling',
+    #                 id=738506197158895616,
+    #                 displayname='James Cowling',
+    #                 rawDescription='@convex_dev co-founder. Infrastructure person. Reformed academic. Maker of things. Karaoke enthusiast.',
+    # renderedDescription='@convex_dev co-founder. Infrastructure person. Reformed academic. Maker of things. Karaoke enthusiast.',
+    # descriptionLinks=None,
+    # verified=False,
+    # created=timezone.datetime(2016, 6, 2, 23, 2, 53, tzinfo=tz),
+    # followersCount=805,
+    # friendsCount=165,
+    # statusesCount=187,
+    # favouritesCount=267,
+    # listedCount=19,
+    # mediaCount=8,
+    # location='San Francisco,CA',
+    # protected=False,
+    # link=TextLink(text='convex.dev',
+    # url='http://convex.dev',
+    # tcourl='https://t.co/HAhmzsryzZ',
+    # indices=(0,
+    # 23)),
+    # profileImageUrl='https://pbs.twimg.com/profile_images/1550543886610640896/3JztoI2B_normal.jpg',
+    # profileBannerUrl='https://pbs.twimg.com/profile_banners/738506197158895616/1661050219',
+    # label=None),
+    # replyCount=57,
+    # retweetCount=42,
+    # likeCount=703,
+    # quoteCount=22,
+    # conversationId=1636168208377077760,
+    # lang='en',
+    # source=None,
+    # sourceUrl=None,
+    # sourceLabel=None,
+    # links=None,
+    # media=None,
+    # retweetedTweet=None,
+    # quotedTweet=None,
+    # inReplyToTweetId=None,
+    # inReplyToUser=None,
+    # mentionedUsers=[User(username='datadoghq',
+    # id=123093566,
+    # displayname='Datadog,
+    # Inc.',
+    # rawDescription=None,
+    # renderedDescription=None,
+    # descriptionLinks=None,
+    # verified=None,
+    # created=None,
+    # followersCount=None,
+    # friendsCount=None,
+    # statusesCount=None,
+    # favouritesCount=None,
+    # listedCount=None,
+    # mediaCount=None,
+    # location=None,
+    # protected=None,
+    # link=None,
+    # profileImageUrl=None,
+    # profileBannerUrl=None,
+    # label=None),
+    # User(username='getsentry',
+    # id=464217126,
+    # displayname='Sentry',
+    # rawDescription=None,
+    # renderedDescription=None,
+    # descriptionLinks=None,
+    # verified=None,
+    # created=None,
+    # followersCount=None,
+    # friendsCount=None,
+    # statusesCount=None,
+    # favouritesCount=None,
+    # listedCount=None,
+    # mediaCount=None,
+    # location=None,
+    # protected=None,
+    # link=None,
+    # profileImageUrl=None,
+    # profileBannerUrl=None,
+    # label=None)],
+    # coordinates=None,
+    # place=None,
+    # hashtags=None,
+    # cashtags=None,
+    # card=None,
+    # viewCount=446377,
+    # vibe=None),
+    # inReplyToTweetId=None,
+    # inReplyToUser=None,
+    # mentionedUsers=None,
+    # coordinates=None,
+    # place=None,
+    # hashtags=None,
+    # cashtags=None,
+    # card=SummaryCard(title='Are Tech Companies Aggressively Cutting Back on Vendor Spend?',
+    # url='https://newsletter.pragmaticengineer.com/p/vendor-spend-cuts',
+    # description='A deep dive into why vendor cuts are happening,
+    # which areas are most impacted,
+    # and actionable advice on how to save costs. With data points from more than 70 companies.',
+    # thumbnailUrl='https://pbs.twimg.com/card_img/1635716365712777217/N5WilS7O?format=jpg&name=orig',
+    # siteUser=None,
+    # creatorUser=None),
+    # viewCount=161280,
+    # vibe=None)

--- a/twitter_scrapping/tweets/tests.py
+++ b/twitter_scrapping/tweets/tests.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from django.test import TestCase
 from django.utils import timezone
-from snscrape.modules.twitter import User as SNUser, Tweet as SNTweet
 
 from .fixtures import tweet1, tweet1_updated_tweet, tweet1_updated_user, tweet1_updated_both
 from .models import Tweet, TwitterUser

--- a/twitter_scrapping/tweets/tests.py
+++ b/twitter_scrapping/tweets/tests.py
@@ -211,17 +211,17 @@ class TasksTest(TestCase):
         self.tweet1 = deepcopy(tweet1)
         self.tweet1_incomplete = deepcopy(tweet1_incomplete)
     
-    # @patch('tweets.serializers.SnscrapeTweetSerializer.save')
-    # def test_save_scrapped_tweet(self, save_mock):
-    #     save_scrapped_tweet(self.tweet1)
-    #     save_mock.assert_called()
+    @patch('tweets.serializers.SnscrapeTweetSerializer.save')
+    def test_save_scrapped_tweet(self, save_mock):
+        save_scrapped_tweet(self.tweet1)
+        save_mock.assert_called()
     
-    # @patch('tweets.serializers.SnscrapeTweetSerializer.save')
-    # def test_save_invalid_scrapped_tweet(self, save_mock):
-    #     from rest_framework.serializers import ValidationError
-    #     with self.assertRaises(ValidationError):
-    #         save_scrapped_tweet(self.tweet1_incomplete)
-    #         save_mock.assert_not_called()
+    @patch('tweets.serializers.SnscrapeTweetSerializer.save')
+    def test_save_invalid_scrapped_tweet(self, save_mock):
+        from rest_framework.serializers import ValidationError
+        with self.assertRaises(ValidationError):
+            save_scrapped_tweet(self.tweet1_incomplete)
+            save_mock.assert_not_called()
     
     @patch('snscrape.modules.twitter.TwitterSearchScraper.get_items')
     @patch('snscrape.modules.twitter.TwitterTweetScraper.get_items')


### PR DESCRIPTION
Unifica a lógica no `SnscrapeTweetSerializer`, usando `SnscrapeTwitterUserSerializer` como nested.
Também separa lógica de criação no `scrape_tweets` e adiciona testes para serializers e tasks