### PR TITLE
Atualiza .gitignore para adicionar exports vazia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# Exported files folder
-*/exports/

--- a/twitter_scrapping/exports/.gitignore
+++ b/twitter_scrapping/exports/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
A pasta `/exports` não estava versionada, exigindo que fosse criada manualmente sempre que o repositório é clonado.